### PR TITLE
Split actions settings

### DIFF
--- a/src/main/java/dev/stashy/extrasounds/Mixers.java
+++ b/src/main/java/dev/stashy/extrasounds/Mixers.java
@@ -8,18 +8,22 @@ public class Mixers implements CategoryLoader {
     public static SoundCategory MASTER;
     @Register
     public static SoundCategory INVENTORY;
-    @Register(tooltip = "tooltip.soundCategory.extrasounds_action")
-    public static SoundCategory ACTION;
+    @Register
+    public static SoundCategory HOTBAR;
     @Register
     public static SoundCategory CHAT;
     @Register
     public static SoundCategory CHAT_MENTION;
     @Register
+    public static SoundCategory TYPING;
+    @Register
     public static SoundCategory EFFECTS;
     @Register
-    public static SoundCategory HOTBAR;
+    public static SoundCategory BOW_PULL;
     @Register
-    public static SoundCategory TYPING;
+    public static SoundCategory ENTITY_DEATH;
+    @Register
+    public static SoundCategory REPEATER;
     @Register(toggle = true)
     public static SoundCategory ITEM_DROP;
 }

--- a/src/main/java/dev/stashy/extrasounds/SoundManager.java
+++ b/src/main/java/dev/stashy/extrasounds/SoundManager.java
@@ -250,7 +250,7 @@ public class SoundManager {
             LOGGER.error("[{}] Unknown type of '{}' is approaching: '{}'", ExtraSounds.class.getSimpleName(), EffectType.class.getSimpleName(), type);
             return;
         }
-        playSound(event, SoundType.EFFECT);
+        playSound(event, SoundType.EFFECTS);
     }
 
     public static void playSound(SoundEvent snd, SoundType type) {
@@ -274,13 +274,8 @@ public class SoundManager {
                 MC_RANDOM, position));
     }
 
-    public static void actionSound(SoundEvent snd, BlockPos position) {
-        SoundType action = SoundType.ACTION;
-        playSound(snd, action, 1f, action.pitch, position);
-    }
-
     public static void actionSound(ItemStack stack, BlockPos position) {
-        actionSound(getSoundByStack(stack, SoundType.PICKUP), position);
+        playSound(getSoundByStack(stack, SoundType.PICKUP), SoundType.PICKUP, 1f, 1.0f, position);
     }
 
     public static void playSound(SoundInstance instance) {

--- a/src/main/java/dev/stashy/extrasounds/mixin/action/ClientPlayerEntityMixin.java
+++ b/src/main/java/dev/stashy/extrasounds/mixin/action/ClientPlayerEntityMixin.java
@@ -29,7 +29,7 @@ public abstract class ClientPlayerEntityMixin extends AbstractClientPlayerEntity
             return;
         }
 
-        SoundManager.playSound(Sounds.Actions.BOW_PULL, SoundType.ACTION);
+        SoundManager.playSound(Sounds.Actions.BOW_PULL, SoundType.BOW_PULL);
     }
 
     @Inject(method = "clearActiveItem", at = @At(value = "HEAD"))
@@ -38,6 +38,6 @@ public abstract class ClientPlayerEntityMixin extends AbstractClientPlayerEntity
             return;
         }
 
-        SoundManager.stopSound(Sounds.Actions.BOW_PULL, SoundType.ACTION);
+        SoundManager.stopSound(Sounds.Actions.BOW_PULL, SoundType.BOW_PULL);
     }
 }

--- a/src/main/java/dev/stashy/extrasounds/mixin/action/ClientPlayerInteractionManagerMixin.java
+++ b/src/main/java/dev/stashy/extrasounds/mixin/action/ClientPlayerInteractionManagerMixin.java
@@ -1,6 +1,7 @@
 package dev.stashy.extrasounds.mixin.action;
 
 import dev.stashy.extrasounds.SoundManager;
+import dev.stashy.extrasounds.sounds.SoundType;
 import dev.stashy.extrasounds.sounds.Sounds;
 import net.minecraft.block.*;
 import net.minecraft.block.entity.BlockEntity;
@@ -67,7 +68,7 @@ public abstract class ClientPlayerInteractionManagerMixin {
         if (this.blockState.isOf(Blocks.REPEATER) && this.blockState.contains(RepeaterBlock.DELAY)) {
             // Repeater
             final SoundEvent sound = this.blockState.get(RepeaterBlock.DELAY) == 4 ? Sounds.Actions.REPEATER_RESET : Sounds.Actions.REPEATER_ADD;
-            SoundManager.actionSound(sound, blockPos);
+            SoundManager.playSound(sound, SoundType.REPEATER, 1f, 1f, blockPos);
         } else if (this.blockState.isIn(BlockTags.CAMPFIRES) && (this.blockEntity instanceof CampfireBlockEntity campfireBlockEntity)) {
             // Put item on Campfire
             var recipe = campfireBlockEntity.getRecipeFor(this.currentHandStack);

--- a/src/main/java/dev/stashy/extrasounds/mixin/action/LivingEntityMixin.java
+++ b/src/main/java/dev/stashy/extrasounds/mixin/action/LivingEntityMixin.java
@@ -27,6 +27,6 @@ public abstract class LivingEntityMixin extends Entity {
 
         final float flu = (this.random.nextFloat() - 0.5f) * 0.333333f;
         final float pitch = flu + (float) MathHelper.clampedLerp(2f, 0.5f,  Math.sqrt(this.getHeight() * this.getWidth()) * 0.4f);
-        SoundManager.playSound(Sounds.Entities.POOF, SoundType.ACTION, .7f, pitch, this.getBlockPos());
+        SoundManager.playSound(Sounds.Entities.POOF, SoundType.ENTITY_DEATH, .7f, pitch, this.getBlockPos());
     }
 }

--- a/src/main/java/dev/stashy/extrasounds/sounds/SoundType.java
+++ b/src/main/java/dev/stashy/extrasounds/sounds/SoundType.java
@@ -3,23 +3,23 @@ package dev.stashy.extrasounds.sounds;
 import dev.stashy.extrasounds.Mixers;
 import net.minecraft.sound.SoundCategory;
 
-public enum SoundType
-{
+public enum SoundType {
     PICKUP(1f, Mixers.INVENTORY, "item.pickup"),
     PLACE(0.9f, Mixers.INVENTORY, "item.place"),
     HOTBAR(1f, Mixers.HOTBAR, "item.select"),
-    EFFECT(1f, Mixers.EFFECTS, "effect"),
     CHAT(1f, Mixers.CHAT, "ui.chat"),
     CHAT_MENTION(1f, Mixers.CHAT_MENTION, "ui.chat"),
     TYPING(1f, Mixers.TYPING, "ui.typing"),
-    ACTION(1f, Mixers.ACTION, "action");
+    EFFECTS(1f, Mixers.EFFECTS, "effect"),
+    BOW_PULL(1f, Mixers.BOW_PULL, "bow_pull"),
+    ENTITY_DEATH(1f, Mixers.ENTITY_DEATH, "entity_death"),
+    REPEATER(1f, Mixers.REPEATER, "repeater");
 
     public final float pitch;
     public final SoundCategory category;
     public final String prefix;
 
-    SoundType(float pitch, SoundCategory category, String prefix)
-    {
+    SoundType(float pitch, SoundCategory category, String prefix) {
         this.pitch = pitch;
         this.category = category;
         this.prefix = prefix;

--- a/src/main/resources/assets/extrasounds/lang/en_us.json
+++ b/src/main/resources/assets/extrasounds/lang/en_us.json
@@ -1,13 +1,13 @@
 {
   "soundCategory.extrasounds$master": "ExtraSounds",
   "soundCategory.extrasounds$inventory": "Inventory",
-  "soundCategory.extrasounds$action": "Actions",
+  "soundCategory.extrasounds$hotbar": "Hotbar",
   "soundCategory.extrasounds$chat": "Chat Messages",
   "soundCategory.extrasounds$chat_mention": "Chat Mention",
   "soundCategory.extrasounds$effects": "Effects/Potions",
-  "soundCategory.extrasounds$hotbar": "Hotbar",
   "soundCategory.extrasounds$typing": "Typing",
+  "soundCategory.extrasounds$bow_pull": "Bow Pull",
+  "soundCategory.extrasounds$entity_death": "Entity Dies",
   "soundCategory.extrasounds$item_drop": "Item Drop",
-
-  "tooltip.soundCategory.extrasounds_action": "This volume is applied when Item interactions, Block interactions and Entity events."
+  "soundCategory.extrasounds$repeater": "Repeater"
 }

--- a/src/main/resources/assets/extrasounds/lang/ko_kr.json
+++ b/src/main/resources/assets/extrasounds/lang/ko_kr.json
@@ -1,10 +1,13 @@
 {
   "soundCategory.extrasounds$master": "ExtraSounds",
   "soundCategory.extrasounds$inventory": "목록",
-  "soundCategory.extrasounds$action": "아이템 액션",
+  "soundCategory.extrasounds$hotbar": "단축바",
   "soundCategory.extrasounds$chat": "채팅 메시지",
   "soundCategory.extrasounds$chat_mention": "채팅 언급",
+  "soundCategory.extrasounds$typing": "타이핑",
   "soundCategory.extrasounds$effects": "효과/포션",
-  "soundCategory.scroll": "스크롤링",
-  "soundCategory.extrasounds$typing": "타이핑"
+  "soundCategory.extrasounds$bow_pull": "활 줄",
+  "soundCategory.extrasounds$entity_death": "엔터티가 죽다",
+  "soundCategory.extrasounds$item_drop": "선택한 아이템 떨어뜨리기",
+  "soundCategory.extrasounds$repeater": "레드스톤 중계기"
 }

--- a/src/main/resources/assets/extrasounds/lang/ru_ru.json
+++ b/src/main/resources/assets/extrasounds/lang/ru_ru.json
@@ -1,10 +1,13 @@
 {
   "soundCategory.extrasounds$master": "ExtraSounds",
   "soundCategory.extrasounds$inventory": "Инвентарь",
-  "soundCategory.extrasounds$action": "Действия с предметами",
+  "soundCategory.extrasounds$hotbar": "Хотбар",
   "soundCategory.extrasounds$chat": "Сообщения в чате",
   "soundCategory.extrasounds$chat_mention": "Упоминания в чате",
+  "soundCategory.extrasounds$typing": "Ввод текста",
   "soundCategory.extrasounds$effects": "Эффекты/Зелья",
-  "soundCategory.scroll": "Прокрутка",
-  "soundCategory.extrasounds$typing": "Ввод текста"
+  "soundCategory.extrasounds$bow_pull": "Тетива лука",
+  "soundCategory.extrasounds$entity_death": "Сущность погибает",
+  "soundCategory.extrasounds$item_drop": "Выбросить предмет",
+  "soundCategory.extrasounds$repeater": "Повторитель"
 }


### PR DESCRIPTION
## What?
- Splits settings for sounds from the Actions category to "Bow Pull", "Entity Dies" and "Repeater". 
- Arrange the settings more logically, first the GUI sounds, then the game sounds.

## Why?
This gives the player the ability to customize sounds from there individually. For ex, I like the sound of a bow pull, but the "poof" sound of a mob dying annoys me.

## Testing Instructions
1. Launch the game with the mod
2. Open game sound settings -> Extra sounds settings
3. Try changing the settings and check the independence between them

## Screenshot

![image](https://github.com/lonefelidae16/extra-sounds/assets/96978370/0650da5b-e04c-44b0-857f-797cb971b0be)

## Changes
Changes have been made to `SoundType` and `Mixers` to accommodate the new settings list order as well as the associated code.

Also, it is fully keep to translated into Russian and Korean.